### PR TITLE
Remove -InstallDotNetSdkLocally

### DIFF
--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,7 +1,7 @@
 components:
   sandbox:
     script: |
-      pwsh build.ps1 -InstallDotNetSdkLocally
+      pwsh build.ps1
     arguments: ""
 
 defaults: --config ./crank.yml

--- a/build.ps1
+++ b/build.ps1
@@ -5,8 +5,7 @@
 
 param(
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $OutputPath = "",
-    [Parameter(Mandatory = $false)][switch] $InstallDotNetSdkLocally
+    [Parameter(Mandatory = $false)][string] $OutputPath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -21,7 +20,7 @@ if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"
 }
 
-$installDotNetSdk = $InstallDotNetSdkLocally;
+$installDotNetSdk = $false;
 
 if (($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue))) {
     Write-Host "The .NET SDK is not installed."


### PR DESCRIPTION
Remove `-InstallDotNetSdkLocally` as crank should now use `dotnet` from the path, rather than from `.dotnet` the folder since https://github.com/dotnet/crank/pull/396 was published to NuGet.org.
