### PR TITLE
Run benchmarks on Linux

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest ]
+        os: [ ubuntu-latest ]
 
     steps:
 


### PR DESCRIPTION
Run benchmarks on Linux instead of Windows, which should work since https://github.com/dotnet/crank/pull/396 was published to NuGet.org.
