### PR TITLE
Revert to Windows for benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ windows-latest ]
 
     steps:
 


### PR DESCRIPTION
Reverts #14 as it still doesn't work correctly, see https://github.com/martincostello/crank-sandbox/pull/15#issuecomment-1030592059.
